### PR TITLE
Fix token handling bug

### DIFF
--- a/src/routes/__tests__/auth.test.ts
+++ b/src/routes/__tests__/auth.test.ts
@@ -186,6 +186,15 @@ describe('認証ルートのテスト', () => {
             const cookies = res.headers.get('Set-Cookie');
             expect(cookies).toBeTruthy();
             expect(cookies).toContain('refreshToken=refresh_token');
+            expect(createAccessToken).toHaveBeenCalledWith('123', 'test_secret');
+            expect(createRefreshToken).toHaveBeenCalledWith('123', 'test_secret');
+            expect(mockPrisma.refreshToken.create).toHaveBeenCalledWith({
+                data: {
+                    token: 'refresh_token',
+                    userId: '123',
+                    expiresAt: expect.any(Date)
+                }
+            });
         });
 
         it('誤った認証情報ではエラーを返すこと', async () => {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -44,8 +44,8 @@ function generateRandomString(length: number){
     return result
 }
 
-function getEnvString(env: { [key: string]: string }, key: string): string {
-    const value = process.env[key]
+function getEnvString(env: { [key: string]: string | undefined }, key: string): string {
+    const value = env[key] ?? process.env[key]
     if (!value) {
         throw new Error(`❌ ${key} is not set in environment variables!`)
     }
@@ -84,9 +84,16 @@ auth.post('/login', async (c) => {
     }
 
     const JWT_SECRET = getJWTSecret(c.env)
-    const accessToken = createAccessToken(user.email, JWT_SECRET)
-    const refreshToken = createRefreshToken(user.email, JWT_SECRET)
+    const accessToken = createAccessToken(user.id, JWT_SECRET)
+    const refreshToken = createRefreshToken(user.id, JWT_SECRET)
 
+    await prisma.refreshToken.create({
+        data: {
+            token: refreshToken,
+            userId: user.id,
+            expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        }
+    })
 
     //リフレッシュトークンをクッキーに保存, secureはHTTPSのみで送信するようにする, sameSiteはCSRF対策
     setCookie(c, 'refreshToken', refreshToken, {httpOnly: true,secure: true, sameSite: 'Strict', maxAge: 7 * 24 * 60 * 60})


### PR DESCRIPTION
## Summary
- ensure `getEnvString` uses passed environment variables
- store refresh tokens on login and sign JWT with user ID
- validate token creation in tests

## Testing
- `bun test` *(fails: Cannot find package 'hono')*

------
https://chatgpt.com/codex/tasks/task_e_683fc2413d1c832a9bbb352f1e027469